### PR TITLE
This patch resolves issue #1 -- No matching method: with_bindings

### DIFF
--- a/src/leiningen/daemon/daemonProxy.clj
+++ b/src/leiningen/daemon/daemonProxy.clj
@@ -1,6 +1,7 @@
 (ns leiningen.daemon.daemonProxy
   "The entry point for services"
   (:import org.apache.commons.daemon.Daemon)
+  (:refer-clojure :include [with-bindings])
   (:gen-class :name leiningen.daemon.daemonProxy
               :init ctor
               :state state


### PR DESCRIPTION
daemonProxy fails to initialize due to: IllegalArgumentException: No matching method: with_bindings

Cheers,
Eric
