### PR TITLE
Added :extra-classpath daemon option

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-daemon "0.2.1"
+(defproject lein-daemon "0.2.1-SNAPSHOT"
   :dependencies [[commons-daemon "1.0.1"]]
   :dev-dependencies [[org.clojure/clojure "1.2.0"]]
   :aot [leiningen.daemon.daemonProxy])


### PR DESCRIPTION
Hey, I needed to append paths on to the classpath to use lein-daemon with crane.  Attached is a patch that looks at :extra-classpath for extra paths and then appends them to the project's standard classpath definitions and sets the Java instance with the new classpath in the start-handler.

Let me know how you feel about adding this functionality.

An example pulled from one of my project files:

```
:daemon {"aws-poller-scheduler" {:ns "aws-poller-scheduler-daemon"
                                 :args []
                                 :options {:pidfile "aws-poller-scheduler.pid"
                                           :errfile "err.out"
                                           :user "matt"}
                                 :extra-classpath ["crane"]}})
```
