### PR TITLE
Lein 2 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/pom.xml
+/target

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-daemon "0.4.1"
+(defproject lein-daemon "0.5.0-SNAPSHOT"
   :description "A lein plugin that daemonizes a clojure process"
   :url "https://github.com/arohner/leiningen"
   :license {:name "Eclipse Public License"}

--- a/src/leiningen/daemon.clj
+++ b/src/leiningen/daemon.clj
@@ -1,10 +1,9 @@
 (ns leiningen.daemon
-  (:use [leiningen.compile :only [eval-in-project]]
-        [leiningen.core :only [abort]]
+  (:use [leiningen.core.eval :only [eval-in-project]]
+        [leiningen.core.main :only [abort]]
         [leiningen.help :only [help-for]])
   (:import java.io.File)
-  (require [leiningen.daemon-runtime :as runtime])
-  (:use [clojure.contrib.except :only (throwf)]))
+  (require [leiningen.daemon-runtime :as runtime]))
 
 (defn wait-for
   "periodically calls test, a fn of no arguments, until it returns
@@ -69,7 +68,7 @@
     (when (running? project alias)
       (println "sending SIGTERM to" pid)
       (runtime/sigterm pid))
-    (wait-for #(not (running? project alias)) #(throwf "%s failed to stop in %d seconds" alias timeout) timeout)
+    (wait-for #(not (running? project alias)) #(throw (Exception. (format "%s failed to stop in %d seconds" alias timeout))) timeout)
     (-> (get-pid-path project alias) (File.) (.delete))))
 
 (defn check [project alias]

--- a/src/leiningen/daemon.clj
+++ b/src/leiningen/daemon.clj
@@ -109,8 +109,7 @@ USAGE: lein daemon start :foo bar baz
   (let [command (keyword command)
         daemon-name (if (keyword? (read-string daemon-name))
                       (read-string daemon-name)
-                      daemon-name)
-        alias (get-in project [:daemon daemon-name])]
+                      daemon-name)]
     (check-valid-daemon project daemon-name)
     (condp = (keyword command)
       :start (apply start-main project daemon-name args)

--- a/src/leiningen/daemon.clj
+++ b/src/leiningen/daemon.clj
@@ -34,8 +34,10 @@
 
 (defn start-main
   [project alias & args]
-  (let [ns (get-in project [:daemon alias :ns])
-        timeout (* 5 60)]
+  (let [ns          (get-in project [:daemon alias :ns])
+        daemon-args (get-in project [:daemon alias :args] [])
+        all-args    (concat daemon-args args)
+        timeout     (* 5 60)]
     (if (not (pid-present? project alias))
       (do
         (println "starting" alias)
@@ -44,7 +46,7 @@
                                                        (System/setProperty "leiningen.daemon" "true")
                                                        (require 'leiningen.daemon-runtime)
                                                        (leiningen.daemon-runtime/init ~(get-pid-path project alias) :debug ~(get-in project [:daemon alias :debug]))
-                                                       ((ns-resolve '~(symbol ns) '~'-main) ~@args))
+                                                       ((ns-resolve '~(symbol ns) '~'-main) ~@all-args))
                                                     `(do
                                                        (require '~(symbol ns)))))]
           (wait-for #(running? project alias) #(throw (Exception. (format "%s failed to start in %s seconds" alias timeout))) timeout)


### PR DESCRIPTION
First pass at compatibility with Leiningen 2.
- Removes dependency on old contrib (throwf).
- Accounts for Leiningen namespace reorganization.
- Updates eval-in-project to match new (restricted) API.

Limitations:
- Can no longer spawn a background process directly since the ant-based callback has been removed from Leiningen (the .setSpawn call that lein-daemon used to do).
- Usage is now: `lein daemon start :process &` or `nohup lein daemon start :process &`
- `lein daemon stop :process` correctly kills the process but "clojure.lang.ExceptionInfo: Subprocess failed {:exit-code 143}" is displayed
