### PR TITLE
Correct PID path, log filename and daemon name setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/pom.xml
+/target

--- a/src/leiningen/daemon.clj
+++ b/src/leiningen/daemon.clj
@@ -121,7 +121,7 @@ USAGE: lein daemon start :foo bar baz
             (nil? daemon-name))
     (abort (help-for "daemon")))
   (let [command (keyword command)
-        daemon-name (find-daemon-name project (name (read-string daemon-name)))
+        daemon-name (common/get-daemon-name project (name (read-string daemon-name)))
         daemon-args (get-in project [:daemon daemon-name :args])
         args (concat daemon-args args)]
     (condp = (keyword command)

--- a/src/leiningen/daemon.clj
+++ b/src/leiningen/daemon.clj
@@ -58,7 +58,7 @@
   (let [timeout (* 5 60)
         lein (System/getProperty "leiningen.script")
         arg-str (str/join " " args)
-        log-file (format "%s.log" alias)
+        log-file (format "%s.log" (name alias))
         nohup-cmd (format "nohup %s daemon-starter %s %s </dev/null &> %s &" lein (name alias) arg-str log-file)]
     (println "pid not present, starting")
     (when-not lein

--- a/src/leiningen/daemon_starter.clj
+++ b/src/leiningen/daemon_starter.clj
@@ -12,8 +12,8 @@
   (let [daemon-name (common/get-daemon-name project daemon-name)
         info (get-in project [:daemon daemon-name])
         ns (symbol (:ns info))
-        pid-path (common/get-pid-path project alias)
-        debug? (common/debug? project alias)]
+        pid-path (common/get-pid-path project daemon-name)
+        debug? (common/debug? project daemon-name)]
     (eval/eval-in-project (add-daemon-runtime-dependency project)
                           `(do
                              (leiningen.daemon.runtime/init ~pid-path :debug ~debug?)


### PR DESCRIPTION
This pull request addresses the three issues I commented on in your recent commit.

Thanx for implementing :args in the daemon map! I've also verified command line args are passed to the daemon process now.
