### PR TITLE
Allow to place log file outside of project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+.DS_Store
+.lein-failures

--- a/src/leiningen/daemon.clj
+++ b/src/leiningen/daemon.clj
@@ -61,7 +61,7 @@
   (let [timeout (* 5 60)
         arg-str (str/join " " args)
         alias (name alias)
-        log-file (format "%s.log" alias)
+        log-file (get-log-file-path project alias)
         lein (get-lein-script)
         nohup-cmd (format "nohup %s daemon-starter %s %s </dev/null &> %s &" lein alias arg-str log-file)]
     (println "pid not present, starting")

--- a/src/leiningen/daemon/common.clj
+++ b/src/leiningen/daemon/common.clj
@@ -11,8 +11,14 @@
 (defn default-pid-name [daemon-name]
   (format "%s.pid" (name daemon-name)))
 
+(defn default-log-file-name [daemon-name]
+  (format "%s.log" (name daemon-name)))
+
 (defn get-pid-path [project daemon-name]
   (get-in project [:daemon daemon-name :pidfile] (default-pid-name daemon-name)))
+
+(defn get-log-file-path [project daemon-name]
+  (get-in project [:daemon daemon-name :logfile] (default-log-file-name daemon-name)))
 
 (defn get-daemon-name [project name]
   (cond


### PR DESCRIPTION
Hi @arohner!
I've noticed that there is an ability to specify path for the pidfile, but logfile is always stored in project root folder, so here is a fix for that :)
